### PR TITLE
Run `cargo fix` and fix some compiler warnings

### DIFF
--- a/src/readline/context.rs
+++ b/src/readline/context.rs
@@ -11,11 +11,11 @@ pub struct Context {
     pub editor: Editor,
     pub history: History,
     pub mode: Mode,
-    pub completer: Box<Completer>,
+    pub completer: Box<dyn Completer>,
 }
 
 impl Context {
-    pub fn new(comp: Box<Completer>) -> Self {
+    pub fn new(comp: Box<dyn Completer>) -> Self {
         Self {
             editor: Editor::new("> ".into()),
             history: History::new(),

--- a/src/readline/editor.rs
+++ b/src/readline/editor.rs
@@ -33,21 +33,21 @@ pub struct Editor {
 }
 
 pub trait Complete {
-    fn complete(&mut self, completer: &mut Completer);
+    fn complete(&mut self, completer: &mut dyn Completer);
 
-    fn completion_disply(&mut self, completer: &mut Completer);
+    fn completion_disply(&mut self, completer: &mut dyn Completer);
 
     fn completion_clear(&mut self);
 
-    fn completion_next(&mut self, completer: &mut Completer);
+    fn completion_next(&mut self, completer: &mut dyn Completer);
 
-    fn completion_prev(&mut self, completer: &mut Completer);
+    fn completion_prev(&mut self, completer: &mut dyn Completer);
 
     fn swap_completion(&mut self, index: usize);
 }
 
 impl Complete for Editor {
-    fn complete(&mut self, completer: &mut Completer) {
+    fn complete(&mut self, completer: &mut dyn Completer) {
         if self.completer_is_after {
             return;
         }
@@ -82,7 +82,7 @@ impl Complete for Editor {
         self.completer_is_after = false;
     }
 
-    fn completion_disply(&mut self, completer: &mut Completer) {
+    fn completion_disply(&mut self, completer: &mut dyn Completer) {
         let page_size = 10;
         let height = if self.completions.len() < page_size {
             self.completions.len() + 1
@@ -107,7 +107,7 @@ impl Complete for Editor {
         self.write_sub(&completions, height);
     }
 
-    fn completion_next(&mut self, completer: &mut Completer) {
+    fn completion_next(&mut self, completer: &mut dyn Completer) {
         if !self.completer_is_after {
             return;
         }
@@ -123,7 +123,7 @@ impl Complete for Editor {
         self.completion_disply(completer);
     }
 
-    fn completion_prev(&mut self, completer: &mut Completer) {
+    fn completion_prev(&mut self, completer: &mut dyn Completer) {
         if !self.completer_is_after {
             return;
         }


### PR DESCRIPTION
Since, trait objects without an explicit `dyn` are deprecated, rust 1.53 prints a couple of warnings when building mican:
```bash
$ cargo build
   Compiling mican v0.3.0 (/home/cjunior/Downloads/rust/mican)
warning: trait objects without an explicit `dyn` are deprecated
  --> src/readline/context.rs:14:24
   |
14 |     pub completer: Box<Completer>,
   |                        ^^^^^^^^^ help: use `dyn`: `dyn Completer`
   |
   = note: `#[warn(bare_trait_objects)]` on by default
```
Here, I have run `cargo fix` and fixed all of those warnings.