### PR TITLE
Fixes: Allow `env::home_dir()` and remove `Error::description`

### DIFF
--- a/src/commands/cd.rs
+++ b/src/commands/cd.rs
@@ -3,9 +3,11 @@ use token::CommandData;
 use std::env;
 
 // TODO
+
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn run(cmd: CommandData) -> Result<(), String> {
     if cmd.options.is_empty() {
+        #[allow(deprecated)]
         env::set_current_dir(&env::home_dir().unwrap()).unwrap();
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,14 +16,14 @@ fn display_logo() {
     let path = Path::new("logo.txt");
 
     let mut file = match fs::File::open(&path) {
-        Err(why) => panic!("couldn't open: {}", Error::description(&why)),
+        Err(why) => panic!("couldn't open: {}", <dyn Error>::to_string(&why)),
         Ok(file) => file,
     };
 
     let mut s = String::new();
 
     if let Err(e) = file.read_to_string(&mut s) {
-        panic!("couldn't read: {}", Error::description(&e));
+        panic!("couldn't read: {}", <dyn Error>::to_string(&e));
     } else {
         for c in s.chars() {
             match c {


### PR DESCRIPTION
* `env::home_dir()` is deprecated since 1.29.0 since it doesn't work well on Windows. Since, mican is a UNIX shell, I reckon we can allow it to work. 
See: [[1]](https://internals.rust-lang.org/t/deprecate-or-break-fix-std-env-home-dir/7315) and [[2]](https://github.com/rust-lang/rust/pull/51656)

* `Error::description` is deprecated since 1.41. That is replaced with `to_string()` as suggested. https://doc.rust-lang.org/std/error/trait.Error.html#method.description